### PR TITLE
Allow aggregating wcms-modules.json

### DIFF
--- a/.github/workflows/update-wcms-modules.yml
+++ b/.github/workflows/update-wcms-modules.yml
@@ -25,6 +25,11 @@ jobs:
         set -e
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git add wcms-modules.json
-        git commit -m "Autoupdate wcms-modules.json"
-        git push
+        # Commit only if there has been changes
+        if [[ -n $(git status --porcelain wcms-modules.json) ]]; then
+            git add wcms-modules.json
+            git commit -m "Autoupdate wcms-modules.json"
+            git push
+        else
+            echo "No changes to wcms-modules.json"
+        fi


### PR DESCRIPTION
This PR allows aggregating repositories that contain wcms-modules.json, instead (or in addition of) version+summary files.

It also changes a bit the pipeline, to prevent a non-fatal error of having no changes from causing the pipeline to fail.